### PR TITLE
docs: add submission section (Task 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ Open https://ddmswlyuv30b2.cloudfront.net in browser – the app is available gl
 Links
 	•	CloudFront URL: https://ddmswlyuv30b2.cloudfront.net
 	•	S3 Bucket Name: deploywebappstack-deploymentfrontendbucket67ceb713-baqkestilsbo
+
+## Submission
+- CloudFront: https://ddmswlyuv30b2.cloudfront.net
+- S3 Bucket: deploywebappstack-deploymentfrontendbucket67ceb713-baqkestilsbo


### PR DESCRIPTION
## What was done
- S3 bucket (private, OAC) + CloudFront distribution
- Automated deployment with AWS CDK (BucketDeployment)
- CloudFront invalidation on redeploy
- README with steps and links

## Links
- CloudFront URL: https://ddmswlyuv30b2.cloudfront.net
- S3 Bucket Name: deploywebappstack-deploymentfrontendbucket67ceb713-baqkestilsbo

## Notes
- SPA routing enabled (404 -> 200 /index.html)
- Bucket served only via CloudFront (OAC)